### PR TITLE
Added sub- maps on the Impact Page

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -64,9 +64,7 @@ import { SearchComponent } from './search/search.component'
 import { HighlightSearchPipe} from './pipes/highlight-search.pipe'
 
 import { FormsModule } from '@angular/forms';
-import { StoriesMapComponent } from './map/stories-map/stories-map.component';
-import { MembersMapComponent } from './map/members-map/members-map.component';
-import { FundersMapComponent } from './map/funders-map/funders-map.component';
+
 import { BrandingComponent } from './branding/branding.component';
 import { WhocampaignComponent } from './whocampaign/whocampaign.component';
 import { Socialmedia2Component } from './socialmedia2/socialmedia2.component';
@@ -134,9 +132,6 @@ import { ConsentsComponent } from './consents/consents.component'
     PodcastsComponent,
     SearchComponent,
     HighlightSearchPipe,
-    StoriesMapComponent,
-    MembersMapComponent,
-    FundersMapComponent,
     BrandingComponent,
     WhocampaignComponent,
     Socialmedia2Component,

--- a/src/app/map/funders-map/funders-map.component.ts
+++ b/src/app/map/funders-map/funders-map.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import * as L from 'leaflet'
+import { MAP_ATTR, MAP_URL } from 'src/assets/impacts/map/mapurl';
 
 @Component({
   selector: 'app-funders-map',
@@ -16,11 +17,11 @@ export class FundersMapComponent implements OnInit {
 
   ngOnInit(): void {
     this.initMap();
+    localStorage.removeItem('foo-bar'); 
   }
 
- 
-
   private initMap() {
+    
     this.map = L.map('map3',{
       zoomDelta:0.25,
       zoomSnap:0.25,
@@ -30,72 +31,144 @@ export class FundersMapComponent implements OnInit {
       
     }).setView([0.0, 0], 2);
 
-    const tiles = L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/light_nolabels/{z}/{x}/{y}.png',{
+    const tiles = L.tileLayer(MAP_URL,{
       maxZoom: 20,
-      attribution:'Map data © OpenStreetMap contributors'
+      attribution: MAP_ATTR
     });
-
 
     const myIcon = L.icon({
       iconUrl:'assets/icon/favicon.png',
       iconSize:[18, 18]
     })
-    L.marker([-10.25, 33.30], {icon: myIcon}).addTo(this.map)
-    .bindPopup('What this initiative has done to my family is so profound. I am able to appreciate the world of children, and I think I am learning good parenting. It has also challenged me to look at this crazy time I have found myself i through the positive lens of hope.<br> <b style = "color:#5dbcd2;">- Parent in Malawi from Without Orphans </b><br><br> We understand that it is very hard for parents to adjust to the new norm, as they will have their children at home more than they are used to due to schools being closed. [The COVID-19 parenting resources] not only bring relief as we parent, but also challenge parenting in general, for some of us have failed miserably to parent well. It will leave a lasting impact and is amazing we have learnt this through a church in our community. <br> <b style = "color:#5dbcd2;">- Parent from Malawi</b> <br><br> Thanks to parenting tips materials, family relationships are being enhanced.Most of our 23 local church partners have testified to how parents have been awakened to what should be natural and fun in families. Thriving social life relationships in most families have, unfortunately, been non-existent; and thanks to Covid19 as it has simply exposed this fact..<br> <b style = "color:#5dbcd2;">- World Without Orphans, Malawi </b><br><br> If I have found these (tips) helpful, for sure they should be for all parents and caregivers in our village. They are also applicable to people of all faiths, and I will highly recommend to the village head so we could advocate across our community. They are timely.<br> <b style = "color:#5dbcd2;">- Counsellor to village Headman Mphamba in Malawi </b><br><br> Regular radio broadcasts for 11 million')
+
+    L.marker([25.6850, 89.3563], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Bangladesh')
     .openPopup();
 
-    L.marker([40, 139.10], {icon: myIcon}).addTo(this.map)
-    .bindPopup('This isnt just something that helps with the corona disaster, its something that helps with the whole emergency situations. Let us be positive, Im sure that means praising yourself with the little things, not just your kids, but yourself as well.<br> - <b style = "color:#5dbcd2;">Comments on online article, Unicef Japan</b> ')
+    L.marker([15.1657, 104.9910], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Cambodia')
     .openPopup();
 
-    L.marker([7.10, 37.10], {icon: myIcon}).addTo(this.map)
-    .bindPopup('The messages are important and guiding especially this time when adolescents are at home. <br> <b style = "color:#5dbcd2;">- Catholic Relief Services (CRS), Kenya </b><br><br> Safaricom ringtones of COVID-19 parenting song')
+    L.marker([-12.2350, -51.9253], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Brazil')
     .openPopup();
 
-  
-    L.marker([47, 10.10], {icon: myIcon}).addTo(this.map)
-    .bindPopup('The children of the world have an urgent need for safe havens right now, in both a spiritual and physical sense. Spiritual support - through this kind of creative engagement designed especially for children -can give a renewed sense of hope to families and churches alike.<br> <b style = "color:#5dbcd2;">- WCC Interim General Secretary Rev. Prof. Dr Ioan Sauca about the Church Leaders Pack </b>')
+    L.marker([4.5709, -74.2973], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Colombia')
     .openPopup();
 
-    L.marker([27, 76.10], {icon: myIcon}).addTo(this.map)
-    .bindPopup('<b>India:</b> Food parcels and phone based support by community workers')
+    L.marker([51.1657, 10.4515], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Germany')
     .openPopup();
 
-    L.marker([16, 120.10], {icon: myIcon}).addTo(this.map)
-    .bindPopup('<b>Phillipines:</b> National Government and UNICEF webinars for caseworkers and families')
+    L.marker([17.2835, -89.8308], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Guatemala')
     .openPopup();
 
-    L.marker([32, 71.10], {icon: myIcon}).addTo(this.map)
-    .bindPopup('<img style="max-width: -webkit-fill-available;" src="assets/impacts/map/Pakistan.png"/></br><b>Pakistan:</b> National television broadcasts')
+    L.marker([15.2, -86.2419], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Honduras')
     .openPopup();
 
-    L.marker([40, 73.10], {icon: myIcon}).addTo(this.map)
-    .bindPopup('<img style="max-width: -webkit-fill-available;" src="assets/impacts/map/Kyrgyzstan.png"/></br><b>Kyrgyzstan:</b> Cartoon videos on national television reaching over 2 million people')
+    L.marker([64.9631, -19.0208], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Iceland')
     .openPopup();
 
-    L.marker([20, 103.10], {icon: myIcon}).addTo(this.map)
-    .bindPopup('<b>Laos:</b> National Government and UNICEF speakers in 5,800 villages for 50% of population')
+    L.marker([20.5937, 78.9629], {icon: myIcon}).addTo(this.map)
+    .bindPopup('India')
     .openPopup();
 
-    L.marker([16, 103.10], {icon: myIcon}).addTo(this.map)
-    .bindPopup('<img style="max-width: -webkit-fill-available;" src="assets/impacts/map/Thailand.png"/></br><b>Thailand:</b> Government distributed leaflets in Health Promotion hospitals throughout the country')
+    L.marker([53.1424, -6.6921], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Ireland')
     .openPopup();
 
-    L.marker([42, 10.10], {icon: myIcon}).addTo(this.map)
-    .bindPopup('<b>Montenegro:</b> Emergency phone lines, webinars, food parcels')
+    L.marker([21.1096, -76.2975], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Jamaica')
     .openPopup();
 
-    L.marker([-31.5, 19.10], {icon: myIcon}).addTo(this.map)
-    .bindPopup('<b>South Africa:</b> National radio broadcasts in 7 languages')
+    L.marker([0.9236, 37.9062], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Kenya')
     .openPopup();
 
-    L.marker([-25, -55.10], {icon: myIcon}).addTo(this.map)
-    .bindPopup('<b>Paraguay:</b> 1million reached online with the First Lady’s support')
+    L.marker([42.2044, 72.7661], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Kyrgyzstan')
     .openPopup();
 
-    L.marker([15, -85.40], {icon: myIcon}).addTo(this.map)
-    .bindPopup('<b>Guatemala:</b> Ministries of Health and Education')
+    L.marker([4.2105, 102.9758], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Malaysia')
     .openPopup();
+
+    L.marker([23.6345, -102.5528], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Mexico')
+    .openPopup();
+
+    L.marker([42.7087, 19.3744], {icon: myIcon}).addTo(this.map)
+    .bindPopup('*Montenegro')
+    .openPopup();
+
+    L.marker([-22.9576, 16.4904], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Namibia')
+    .openPopup();
+
+    L.marker([33.9522, 36.2332], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Palestine')
+    .openPopup();
+
+    L.marker([-23.4425, -56.4438], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Paraguay')
+    .openPopup();
+
+    L.marker([-9.19, -75.0152], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Peru')
+    .openPopup();
+
+    L.marker([12.8797, 121.774], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Phillipines')
+    .openPopup();
+
+    L.marker([41.3999, -8.2245], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Portugal')
+    .openPopup();
+
+    L.marker([47.6512, 14.9955], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Slovenia')
+    .openPopup();
+
+    L.marker([5.1512, 45.1996], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Somalia')
+    .openPopup();
+
+    L.marker([-30.5595, 22.9375], {icon: myIcon}).addTo(this.map)
+    .bindPopup('South Africa')
+    .openPopup();
+
+    L.marker([7.8731, 80.7718], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Sri-Lanka')
+    .openPopup();
+
+    L.marker([15.87, 100.9925], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Thailand')
+    .openPopup();
+
+    L.marker([2.3733, 32.2903], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Uganda')
+    .openPopup();
+
+    L.marker([50.3794, 29.1656], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Ukraine')
+    .openPopup();
+
+    L.marker([37.0902, -95.7129], {icon: myIcon}).addTo(this.map)
+    .bindPopup('USA')
+    .openPopup();
+
+    L.marker([56.9781, -4.4360], {icon: myIcon}).addTo(this.map)
+    .bindPopup('UK')
+    .openPopup();
+
+    L.marker([24.0583, 105.2772], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Vietnam')
+    .openPopup();
+
     tiles.addTo(this.map);
 
   }

--- a/src/app/map/map.component.html
+++ b/src/app/map/map.component.html
@@ -2,33 +2,28 @@
 <app-newletterribbon></app-newletterribbon>
 <div class="content">
     <div class="tabset">
-        <!-- Tab 1 -->
-        <input type="radio" name="tabset" id="tab1" aria-controls="marzen" checked>
-        <label for="tab1">Stories</label>
-
-        <!---->
-        <!-- Tab 2 
-        <input type="radio" name="tabset" id="tab2" aria-controls="rauchbier">
-        <label for="tab2">Members</label>-->
-        <!-- Tab 
-        <input type="radio" name="tabset" id="tab3" aria-controls="dunkles">
-        <label for="tab3">Funders</label>3 -->
+        <input type="radio" name="tabset" id="tab1" aria-controls="marzen" checked (click)="loadStoriesComponent()">
+        <label for="tab1">STORIES</label>
+       
+        <input type="radio" name="tabset" id="tab2" aria-controls="rauchbier" (click)="loadMembersComponent()">
+        <label for="tab2">UNICEF Partners</label>
+        
+        <input type="radio" name="tabset" id="tab3" aria-controls="dunkles" (click)="loadFundersComponent()">
+        <label for="tab3">GOVERNMENT Partners</label>
         
         <div class="tab-panels">
           <section class="tab-panel">
             <h2>Stories</h2>
-            <app-stories-map></app-stories-map>            
+            <ng-template #storiesmaptemp></ng-template>
         </section>
           <section class="tab-panel">
-            <h2>Members</h2>
-            <app-members-map></app-members-map>
-            
+            <h2>UNICEF Partners</h2>
+            <ng-template #membersmaptemp></ng-template>
           </section>
           <section class="tab-panel">
-            <h2>Funders</h2>
-            <app-funders-map></app-funders-map>
+            <h2>GOVERNMENT Partners</h2>
+            <ng-template #fundersmaptemp></ng-template>
           </section>
         </div>
-        
       </div>
 </div>

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit } from '@angular/core';
-
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { ViewContainerRef } from '@angular/core';
+import { ComponentFactoryResolver } from '@angular/core';
 @Component({
   selector: 'app-map',
   templateUrl: './map.component.html',
@@ -7,12 +8,52 @@ import { Component, OnInit } from '@angular/core';
 })
 export class MapComponent implements OnInit {
 
+  @ViewChild('membersmaptemp', {read: ViewContainerRef})
+  private membersviewcontainerref: ViewContainerRef;
 
-  constructor() { }
+  @ViewChild('fundersmaptemp', {read: ViewContainerRef})
+  private fundersviewcontainerref: ViewContainerRef;
 
-  ngOnInit(): void {
+  @ViewChild('storiesmaptemp', {read: ViewContainerRef})
+  private storiesviewcontainerref: ViewContainerRef;
+
+  constructor(private vcref: ViewContainerRef, private cfr: ComponentFactoryResolver) { }
+
+  ngOnInit() {
+    localStorage.setItem('foo', 'stories')
+    localStorage.setItem('bar', 'members')
+    localStorage.setItem('foo-bar', 'funders')
+    this.loadStoriesComponent();  
   }
 
- 
+  async loadStoriesComponent(){
+    if(localStorage.getItem('foo')){
+      const {StoriesMapComponent} = await import('./stories-map/stories-map.component')
+      this.storiesviewcontainerref.createComponent(this.cfr.resolveComponentFactory(StoriesMapComponent));
+    }
+   else{
+    this.vcref.clear();
+   }
+  }
 
+ async loadMembersComponent(){
+  if(localStorage.getItem('bar')){
+   const {MembersMapComponent} = await import('./members-map/members-map.component')
+  // let membersmapcomp = this.vcref.createComponent(this.cfr.resolveComponentFactory(MembersMapComponent));
+    this.membersviewcontainerref.createComponent(this.cfr.resolveComponentFactory(MembersMapComponent));
+  }
+  else{
+    this.vcref.clear();
+  }
+  }
+
+  async loadFundersComponent(){
+    if(localStorage.getItem('foo-bar')){
+      const {FundersMapComponent} = await import('./funders-map/funders-map.component')
+      this.fundersviewcontainerref.createComponent(this.cfr.resolveComponentFactory(FundersMapComponent));
+    } 
+    else{
+      this.vcref.clear();
+    }
+   }  
 }

--- a/src/app/map/members-map/members-map.component.ts
+++ b/src/app/map/members-map/members-map.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit, AfterViewInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import * as L from 'leaflet'
+import { MAP_ATTR, MAP_URL } from 'src/assets/impacts/map/mapurl';
 
 @Component({
   selector: 'app-members-map',
@@ -7,20 +8,19 @@ import * as L from 'leaflet'
   styleUrls: ['./members-map.component.scss']
 })
 
-export class MembersMapComponent implements AfterViewInit {
+export class MembersMapComponent implements OnInit {
 
-  private m;
+  private map;
 
   constructor() { }
 
-  ngAfterViewInit(): void {
+  ngOnInit(): void { 
     this.initMap();
+    localStorage.removeItem('bar'); 
   }
 
- 
-
   private initMap() {
-    this.m = L.map('map2',{
+    this.map = L.map('map2',{
       zoomDelta:0.25,
       zoomSnap:0.25,
       minZoom: 2,
@@ -29,74 +29,137 @@ export class MembersMapComponent implements AfterViewInit {
       
     }).setView([0.0, 0], 2);
 
-    const tiles = L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/light_nolabels/{z}/{x}/{y}.png',{
+    const tiles = L.tileLayer(MAP_URL,{
       maxZoom: 20,
-      attribution:'Map data © OpenStreetMap contributors'
+      attribution:MAP_ATTR
     });
-
 
     const myIcon = L.icon({
       iconUrl:'assets/icon/favicon.png',
       iconSize:[18, 18]
     })
-    L.marker([-10.25, 33.30], {icon: myIcon}).addTo(this.m)
-    .bindPopup('What this initiative has done to my family is so profound. I am able to appreciate the world of children, and I think I am learning good parenting. It has also challenged me to look at this crazy time I have found myself i through the positive lens of hope.<br> <b style = "color:#5dbcd2;">- Parent in Malawi from Without Orphans </b><br><br> We understand that it is very hard for parents to adjust to the new norm, as they will have their children at home more than they are used to due to schools being closed. [The COVID-19 parenting resources] not only bring relief as we parent, but also challenge parenting in general, for some of us have failed miserably to parent well. It will leave a lasting impact and is amazing we have learnt this through a church in our community. <br> <b style = "color:#5dbcd2;">- Parent from Malawi</b> <br><br> Thanks to parenting tips materials, family relationships are being enhanced.Most of our 23 local church partners have testified to how parents have been awakened to what should be natural and fun in families. Thriving social life relationships in most families have, unfortunately, been non-existent; and thanks to Covid19 as it has simply exposed this fact..<br> <b style = "color:#5dbcd2;">- World Without Orphans, Malawi </b><br><br> If I have found these (tips) helpful, for sure they should be for all parents and caregivers in our village. They are also applicable to people of all faiths, and I will highly recommend to the village head so we could advocate across our community. They are timely.<br> <b style = "color:#5dbcd2;">- Counsellor to village Headman Mphamba in Malawi </b><br><br> Regular radio broadcasts for 11 million')
+    
+    L.marker([33.9391, 65.7100], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Afghanistan')
     .openPopup();
 
-    L.marker([40, 139.10], {icon: myIcon}).addTo(this.m)
-    .bindPopup('This isnt just something that helps with the corona disaster, its something that helps with the whole emergency situations. Let us be positive, Im sure that means praising yourself with the little things, not just your kids, but yourself as well.<br> - <b style = "color:#5dbcd2;">Comments on online article, Unicef Japan</b> ')
+    L.marker([41.2533, 21.4683], {icon: myIcon}).addTo(this.map)
+    .bindPopup('*Albania')
     .openPopup();
 
-    L.marker([7.10, 37.10], {icon: myIcon}).addTo(this.m)
-    .bindPopup('The messages are important and guiding especially this time when adolescents are at home. <br> <b style = "color:#5dbcd2;">- Catholic Relief Services (CRS), Kenya </b><br><br> Safaricom ringtones of COVID-19 parenting song')
+    L.marker([28.0339, 1.6596], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Algeria')
     .openPopup();
 
-  
-    L.marker([47, 10.10], {icon: myIcon}).addTo(this.m)
-    .bindPopup('The children of the world have an urgent need for safe havens right now, in both a spiritual and physical sense. Spiritual support - through this kind of creative engagement designed especially for children -can give a renewed sense of hope to families and churches alike.<br> <b style = "color:#5dbcd2;">- WCC Interim General Secretary Rev. Prof. Dr Ioan Sauca about the Church Leaders Pack </b>')
+    L.marker([25.6850, 89.3563], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Bangladesh')
     .openPopup();
 
-    L.marker([27, 76.10], {icon: myIcon}).addTo(this.m)
-    .bindPopup('<b>India:</b> Food parcels and phone based support by community workers')
+    L.marker([15.1657, 104.9910], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Cambodia')
     .openPopup();
 
-    L.marker([16, 120.10], {icon: myIcon}).addTo(this.m)
-    .bindPopup('<b>Phillipines:</b> National Government and UNICEF webinars for caseworkers and families')
+    L.marker([45.1, 17.2], {icon: myIcon}).addTo(this.map)
+    .bindPopup('*Croatia')
     .openPopup();
 
-    L.marker([32, 71.10], {icon: myIcon}).addTo(this.m)
-    .bindPopup('<img style="max-width: -webkit-fill-available;" src="assets/impacts/map/Pakistan.png"/></br><b>Pakistan:</b> National television broadcasts')
+    L.marker([13.7943, -85.8965], {icon: myIcon}).addTo(this.map)
+    .bindPopup('El Salvador')
     .openPopup();
 
-    L.marker([40, 73.10], {icon: myIcon}).addTo(this.m)
-    .bindPopup('<img style="max-width: -webkit-fill-available;" src="assets/impacts/map/Kyrgyzstan.png"/></br><b>Kyrgyzstan:</b> Cartoon videos on national television reaching over 2 million people')
+    L.marker([64.9631, -19.0208], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Iceland')
     .openPopup();
 
-    L.marker([20, 103.10], {icon: myIcon}).addTo(this.m)
-    .bindPopup('<b>Laos:</b> National Government and UNICEF speakers in 5,800 villages for 50% of population')
+    L.marker([20.5937, 78.9629], {icon: myIcon}).addTo(this.map)
+    .bindPopup('India')
     .openPopup();
 
-    L.marker([16, 103.10], {icon: myIcon}).addTo(this.m)
-    .bindPopup('<img style="max-width: -webkit-fill-available;" src="assets/impacts/map/Thailand.png"/></br><b>Thailand:</b> Government distributed leaflets in Health Promotion hospitals throughout the country')
+    L.marker([-0.1893, 112.9213], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Indonesia')
     .openPopup();
 
-    L.marker([42, 10.10], {icon: myIcon}).addTo(this.m)
-    .bindPopup('<b>Montenegro:</b> Emergency phone lines, webinars, food parcels')
+    L.marker([33.2232, 43.6793], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Iraq')
     .openPopup();
 
-    L.marker([-31.5, 19.10], {icon: myIcon}).addTo(this.m)
-    .bindPopup('<b>South Africa:</b> National radio broadcasts in 7 languages')
+    L.marker([21.1096, -76.2975], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Jamaica')
     .openPopup();
 
-    L.marker([-25, -55.10], {icon: myIcon}).addTo(this.m)
-    .bindPopup('<b>Paraguay:</b> 1million reached online with the First Lady’s support')
+    L.marker([36.2084, 135.2529], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Japan')
     .openPopup();
 
-    L.marker([15, -85.40], {icon: myIcon}).addTo(this.m)
-    .bindPopup('<b>Guatemala:</b> Ministries of Health and Education')
+    L.marker([31.98523, 36.9384 ], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Jordan')
     .openPopup();
-    tiles.addTo(this.m);
 
+    L.marker([0.9236, 37.9062], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Kenya')
+    .openPopup();
+
+    L.marker([19.8563, 102.4955], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Laos')
+    .openPopup();
+
+    L.marker([-28.610, 28.2336], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Lesotho')
+    .openPopup();
+
+    L.marker([4.2105, 102.9758], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Malaysia')
+    .openPopup();
+
+    L.marker([3.9028, 74.2207], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Maldives')
+    .openPopup();
+
+    L.marker([46.8625, 103.8467], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Mongolia')
+    .openPopup();
+
+    L.marker([42.7087, 19.3744], {icon: myIcon}).addTo(this.map)
+    .bindPopup('*Montenegro')
+    .openPopup();
+
+    L.marker([21.9162, 95.956], {icon: myIcon}).addTo(this.map)
+    .bindPopup('*Myanmar')
+    .openPopup();
+
+    L.marker([33.9522, 36.2332], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Palestine')
+    .openPopup();
+
+    L.marker([9.538, -78.7821], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Panama')
+    .openPopup();
+
+    L.marker([-3.0122, 150.347], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Papua New Guinea')
+    .openPopup();
+
+    L.marker([12.8797, 121.774], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Phillipines')
+    .openPopup();
+
+    L.marker([-30.5595, 22.9375], {icon: myIcon}).addTo(this.map)
+    .bindPopup('South Africa')
+    .openPopup();
+
+    L.marker([15.87, 100.9925], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Thailand')
+    .openPopup();
+
+    L.marker([-7.1742, 125.1275], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Timor Leste')
+    .openPopup();
+
+    L.marker([8.4238, -66.5897], {icon: myIcon}).addTo(this.map)
+    .bindPopup('Venezuela')
+    .openPopup();
+
+    tiles.addTo(this.map);
   }
 
 }

--- a/src/app/map/stories-map/stories-map.component.ts
+++ b/src/app/map/stories-map/stories-map.component.ts
@@ -1,5 +1,6 @@
 import { AfterViewInit, Component, OnInit } from '@angular/core';
 import * as L from 'leaflet'
+import { MAP_ATTR, MAP_URL } from 'src/assets/impacts/map/mapurl';
 
 @Component({
   selector: 'app-stories-map',
@@ -14,11 +15,11 @@ export class StoriesMapComponent implements OnInit {
 
   constructor() { }
 
-  ngOnInit(): void {
+  ngOnInit(): void { 
     this.initMap();
+    localStorage.removeItem('foo'); 
   }
 
- 
 
   private initMap() {
     this.map = L.map('map',{
@@ -26,22 +27,19 @@ export class StoriesMapComponent implements OnInit {
       zoomSnap:0.25,
       minZoom: 2,
       maxZoom:2,
-      dragging: false,
-      zoomControl: false,
-      //scrollWheelZoom: false
-      //boxZoom: false
+      dragging: false
     }).setView([0.0, 0], 2);
 
-    const tiles = L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/light_nolabels/{z}/{x}/{y}.png',{
+    const tiles = L.tileLayer(MAP_URL,{
       maxZoom: 20,
-      attribution:'Map data © OpenStreetMap contributors'
+      attribution:MAP_ATTR
     });
-
 
     const myIcon = L.icon({
       iconUrl:'assets/icon/favicon.png',
       iconSize:[18, 18]
     })
+    
     L.marker([-10.25, 33.30], {icon: myIcon}).addTo(this.map)
     .bindPopup('What this initiative has done to my family is so profound. I am able to appreciate the world of children, and I think I am learning good parenting. It has also challenged me to look at this crazy time I have found myself i through the positive lens of hope.<br> <b style = "color:#5dbcd2;">- Parent in Malawi from Without Orphans </b><br><br> We understand that it is very hard for parents to adjust to the new norm, as they will have their children at home more than they are used to due to schools being closed. [The COVID-19 parenting resources] not only bring relief as we parent, but also challenge parenting in general, for some of us have failed miserably to parent well. It will leave a lasting impact and is amazing we have learnt this through a church in our community. <br> <b style = "color:#5dbcd2;">- Parent from Malawi</b> <br><br> Thanks to parenting tips materials, family relationships are being enhanced.Most of our 23 local church partners have testified to how parents have been awakened to what should be natural and fun in families. Thriving social life relationships in most families have, unfortunately, been non-existent; and thanks to Covid19 as it has simply exposed this fact..<br> <b style = "color:#5dbcd2;">- World Without Orphans, Malawi </b><br><br> If I have found these (tips) helpful, for sure they should be for all parents and caregivers in our village. They are also applicable to people of all faiths, and I will highly recommend to the village head so we could advocate across our community. They are timely.<br> <b style = "color:#5dbcd2;">- Counsellor to village Headman Mphamba in Malawi </b><br><br> Regular radio broadcasts for 11 million')
     .openPopup();
@@ -99,7 +97,6 @@ export class StoriesMapComponent implements OnInit {
     .bindPopup('<b>Guatemala:</b> Ministries of Health and Education')
     .openPopup();
     tiles.addTo(this.map);
-
   }
 
 }

--- a/src/assets/impacts/map/mapurl.ts
+++ b/src/assets/impacts/map/mapurl.ts
@@ -1,0 +1,2 @@
+export const MAP_URL = 'https://{s}.basemaps.cartocdn.com/rastertiles/light_nolabels/{z}/{x}/{y}.png';
+export const MAP_ATTR = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'


### PR DESCRIPTION
**What this PR does**
The impact map section of the webiste has been updated with 2 more maps, UNICEF and Government partners as well.

**What needs to be done**

- @maxwellfundi the two tabs still possess placeholder text that is similar to the one in the Stories section. We will need to update this text once received, for now, the 3 maps have the same text. ( I refer to the text that beings with _"The COVID-19 Playful Parenting team's collaboration has brought together ........._)
- The "reverse switch" of the colors Gray and White on the map area to replace each other is impossible while using the leaflet's open-source API. We were able to find a solution BUT it's premium API. I will share this soon for the team to review

**Screenshots**
<img width="1173" alt="Screenshot 2021-08-17 at 14 24 09" src="https://user-images.githubusercontent.com/24493616/129717912-4ca6e1df-41e9-4f67-aa29-52db6f573c4d.png">

Thanks, @FaithDaka for your efforts in getting this live